### PR TITLE
Integrate choking flow and demo readiness fixes

### DIFF
--- a/choking_handler.py
+++ b/choking_handler.py
@@ -2,14 +2,16 @@ import random
 import threading
 import bitfield
 
+
 class ChokingHandler:
-    def __init__(self, peer_id, logger, k, p_interval, m_interval):
+    def __init__(self, peer_id, logger, k, p_interval, m_interval, bitfield_state=None, state_change_callback=None):
         self.peer_id = peer_id
         self.logger = logger
         self.k = k
         self.p_interval = p_interval
         self.m_interval = m_interval
-        self.bitfield = bitfield
+        self.bitfield = bitfield_state if bitfield_state is not None else bitfield
+        self.state_change_callback = state_change_callback
 
         self.neighbors = {}
         self.optimistic_neighbor_id = None
@@ -25,6 +27,11 @@ class ChokingHandler:
     def add_neighbor(self, neighbor_id):
         with self.lock:
             self.neighbors[neighbor_id] = {"interested": False, "choked": True, "num_bytes_received": 0 }
+
+    def remove_neighbor(self, neighbor_id):
+        with self.lock:
+            self.neighbors.pop(neighbor_id, None)
+
     def set_interested(self, neighbor_id, is_interested):
         with self.lock:
             if neighbor_id in self.neighbors:
@@ -61,6 +68,10 @@ class ChokingHandler:
                 if self.neighbors[neighbor_id]["interested"]:
                     list_interested.append(neighbor_id)
             if len(list_interested) == 0:
+                for id in self.neighbors:
+                    if id != self.optimistic_neighbor_id:
+                        self.neighbors[id]["choked"] = True
+                self._notify_state_change()
                 return
             
             # if the file is complete, then we randomly choose k neighbors
@@ -81,6 +92,7 @@ class ChokingHandler:
                 self.neighbors[id]["num_bytes_received"] = 0
             
             self.logger.change_preferred_neighbors(chosen_neighbor)
+            self._notify_state_change()
     
     def complete_file(self):
         return self.bitfield.is_complete()
@@ -135,6 +147,7 @@ class ChokingHandler:
             self.optimistic_neighbor_id = random.choice(choked_interested)
             self.neighbors[self.optimistic_neighbor_id]["choked"] = False
             self.logger.change_optimistic_unchoked_neighbors(self.optimistic_neighbor_id)
+            self._notify_state_change()
 
     def stop(self):
         # does the ptimer exist, only then cancel
@@ -143,6 +156,15 @@ class ChokingHandler:
         
         if hasattr(self, 'mtimer'):
             self.mtimer.cancel()
+
+    def _notify_state_change(self):
+        if self.state_change_callback is None:
+            return
+
+        snapshot = {}
+        for neighbor_id, state in self.neighbors.items():
+            snapshot[neighbor_id] = state["choked"]
+        self.state_change_callback(snapshot)
 
 
 

--- a/connection_manager/network.py
+++ b/connection_manager/network.py
@@ -4,6 +4,7 @@
 import socket
 import struct
 import threading
+import time
 from typing import Dict, Optional, Tuple
 
 from protocol.framing import recv_message, send_message as send_protocol_message
@@ -61,6 +62,8 @@ class PeerNode:
 
         # lock to protect the connections dict so multiple threads don't mess it up
         self.conn_lock = threading.Lock()
+        # lock so framed sends do not interleave on the same socket
+        self.send_lock = threading.Lock()
         # dict mapping peer_id -> socket for all active connections
         self.connections: Dict[int, socket.socket] = {}
         # dict mapping peer_id -> thread for each peer's reader thread
@@ -170,25 +173,44 @@ class PeerNode:
     def _connect_to_peer(self, peer_id: int) -> None:
         # initiate an outgoing connection to a specific peer
         peer = self.peers[peer_id]
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        last_error: Optional[Exception] = None
 
-        print(f"[{self.self_id}] Connecting to {peer_id} at {peer.host}:{peer.port} ...")
-        sock.connect((peer.host, peer.port))
+        for _ in range(20):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
-        # spec says: outgoing connection, we send handshake first
-        sock.sendall(build_handshake(self.self_id))
-        # then wait for their handshake back
-        their = recv_exact(sock, HANDSHAKE_LEN)
-        remote_id = parse_handshake(their)
+            try:
+                print(f"[{self.self_id}] Connecting to {peer_id} at {peer.host}:{peer.port} ...")
+                sock.connect((peer.host, peer.port))
 
-        # make sure we got a handshake from the right peer
-        if remote_id != peer_id:
-            sock.close()
-            raise ValueError(f"Connected to wrong peer: expected {peer_id}, got {remote_id}")
+                # spec says: outgoing connection, we send handshake first
+                sock.sendall(build_handshake(self.self_id))
+                # then wait for their handshake back
+                their = recv_exact(sock, HANDSHAKE_LEN)
+                remote_id = parse_handshake(their)
 
-        # add this connection to our active connections
-        self._register_connection(remote_id, sock, incoming=False)
+                # make sure we got a handshake from the right peer
+                if remote_id != peer_id:
+                    raise ValueError(f"Connected to wrong peer: expected {peer_id}, got {remote_id}")
+
+                # add this connection to our active connections
+                self._register_connection(remote_id, sock, incoming=False)
+                return
+            except ConnectionRefusedError as exc:
+                last_error = exc
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+                time.sleep(0.5)
+            except Exception:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+                raise
+
+        raise ConnectionError(f"Could not connect to peer {peer_id}") from last_error
 
     def _register_connection(self, remote_id: int, sock: socket.socket, incoming: bool) -> None:
         # add a new connection to our list and start a reader thread for it
@@ -205,6 +227,11 @@ class PeerNode:
         # print whether this was an incoming or outgoing connection
         direction = "IN " if incoming else "OUT"
         print(f"[{self.self_id}] {direction} connected with peer {remote_id}")
+        if hasattr(self, "logger"):
+            if incoming:
+                self.logger.log_tcp_connection_from_peer(remote_id)
+            else:
+                self.logger.log_tcp_connection_to_peer(remote_id)
 
         # call the on_connected hook so the protocol layer knows we're ready
         self.on_connected(remote_id)
@@ -245,7 +272,8 @@ class PeerNode:
         if sock is None:
             raise ConnectionError(f"Peer {remote_id} is not connected")
 
-        send_protocol_message(sock, msg)
+        with self.send_lock:
+            send_protocol_message(sock, msg)
 
     def on_connected(self, remote_id: int) -> None:
         # called when handshake is done and connection is active

--- a/connection_manager/peerProcess.py
+++ b/connection_manager/peerProcess.py
@@ -44,6 +44,10 @@ def main():
             time.sleep(2)
             # show which peers we're connected to
             print(f"[{peer_id}] Connected peers: {node.get_connected_peer_ids()}")
+            if node.is_network_complete():
+                print(f"[{peer_id}] All peers completed. Shutting down...")
+                node.shutdown()
+                break
     except KeyboardInterrupt:
         # shutdown when user presses Ctrl+C
         print(f"[{peer_id}] Shutting down...")

--- a/connection_manager/protocol_node.py
+++ b/connection_manager/protocol_node.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 import os
+import random
 import threading
 from typing import Optional
 
 from bitfield import Bitfield
+from choking_handler import ChokingHandler
 from logger import PeerLogger
 from protocol.messages import (
     Message,
@@ -91,6 +93,7 @@ class PeerMessageState:
     # like are they choking us, are we interested in their stuff, etc
     peer_bitfield: Bitfield
     peer_choking_me: bool = True  # they start out choking us
+    am_choking_peer: bool = True  # we also start out choking them
     am_interested: bool = False  # we start out not interested
     peer_interested: bool = False  # they start out not interested in us
     requested_piece: Optional[int] = None  # which piece we asked them for (if any)
@@ -115,6 +118,24 @@ class ProtocolPeerNode(PeerNode):
         self.pending_requests: set[int] = set()
         self.peer_states: dict[int, PeerMessageState] = {}
         self.state_lock = threading.Lock()
+        self.all_complete_event = threading.Event()
+        self.choking_handler = ChokingHandler(
+            self_id,
+            logger,
+            common.k,
+            common.unchoke_interval,
+            common.optimistic_unchoke_interval,
+            bitfield_state=self.local_bitfield,
+            state_change_callback=self._on_choke_state_change,
+        )
+
+    def start(self) -> None:
+        super().start()
+        self.choking_handler.start_timer()
+
+    def shutdown(self) -> None:
+        self.choking_handler.stop()
+        super().shutdown()
 
     def on_connected(self, remote_id: int) -> None:
         # called right after handshake finishes with a new peer
@@ -124,14 +145,13 @@ class ProtocolPeerNode(PeerNode):
                 remote_id,
                 PeerMessageState(peer_bitfield=Bitfield(self.common.num_pieces)),
             )
+        self.choking_handler.add_neighbor(remote_id)
 
         # spec says: send bitfield right after handshake (skip if we have nothing)
         if not self.local_bitfield.is_empty():
             self.send_message(remote_id, Message(MsgType.BITFIELD, self.local_bitfield.to_bytes()))
 
-        # TODO: once choking handler is wired in, remove this placeholder unchoke
-        # for now just unchoke everyone so pieces actually flow
-        self.send_message(remote_id, Message(MsgType.UNCHOKE))
+        self._update_completion_state()
 
     def on_message(self, remote_id: int, msg: Message) -> None:
         # this gets called every time a full message comes in from a peer
@@ -155,6 +175,8 @@ class ProtocolPeerNode(PeerNode):
             state = self.peer_states.pop(remote_id, None)
             if state is not None and state.requested_piece is not None:
                 self.pending_requests.discard(state.requested_piece)
+        self.choking_handler.remove_neighbor(remote_id)
+        self._update_completion_state()
 
     def _handle_choke(self, remote_id: int, msg: Message) -> None:
         # they choked us so we cant request pieces from them anymore
@@ -178,12 +200,14 @@ class ProtocolPeerNode(PeerNode):
         # they want something we have
         with self.state_lock:
             self._get_state(remote_id).peer_interested = True
+        self.choking_handler.set_interested(remote_id, True)
         self.logger.receiving_interested(remote_id)
 
     def _handle_not_interested(self, remote_id: int, msg: Message) -> None:
         # they dont need anything from us anymore
         with self.state_lock:
             self._get_state(remote_id).peer_interested = False
+        self.choking_handler.set_interested(remote_id, False)
         self.logger.receiving_not_interested(remote_id)
 
     def _handle_have(self, remote_id: int, msg: Message) -> None:
@@ -197,6 +221,7 @@ class ProtocolPeerNode(PeerNode):
 
         self._sync_interest(remote_id)
         self._request_next_piece(remote_id)
+        self._update_completion_state()
 
     def _handle_bitfield(self, remote_id: int, msg: Message) -> None:
         # spec says this is the first message after handshake
@@ -208,11 +233,16 @@ class ProtocolPeerNode(PeerNode):
 
         self._sync_interest(remote_id)
         self._request_next_piece(remote_id)
+        self._update_completion_state()
 
     def _handle_request(self, remote_id: int, msg: Message) -> None:
         # they asked us for a specific piece
         # read it from disk and send it back
         piece_index = parse_request_payload(msg.payload)
+
+        with self.state_lock:
+            if self._get_state(remote_id).am_choking_peer:
+                return
 
         # ignore requests for pieces we do not currently have
         if not self.local_bitfield.has_piece(piece_index):
@@ -244,6 +274,7 @@ class ProtocolPeerNode(PeerNode):
                 piece_count = self.local_bitfield.count()
 
         if piece_data and not already_had_piece:
+            self.choking_handler.record_bytes_received(remote_id, len(piece_data))
             self.logger.downloading_piece(remote_id, piece_index, piece_count)
 
             if self.local_bitfield.is_complete():
@@ -253,6 +284,7 @@ class ProtocolPeerNode(PeerNode):
 
         self._refresh_interest_for_all_peers()
         self._request_next_piece(remote_id)
+        self._update_completion_state()
 
     def _sync_interest(self, remote_id: int) -> None:
         # check if they have any pieces we dont
@@ -293,10 +325,13 @@ class ProtocolPeerNode(PeerNode):
 
     def _choose_piece_to_request(self, peer_bitfield: Bitfield) -> Optional[int]:
         # find a piece they have that we dont, and that nobody else is sending us already
+        candidates = []
         for piece_index in self.local_bitfield.interesting_pieces(peer_bitfield):
             if piece_index not in self.pending_requests:
-                return piece_index
-        return None
+                candidates.append(piece_index)
+        if not candidates:
+            return None
+        return random.choice(candidates)
 
     def _broadcast_have(self, piece_index: int) -> None:
         # spec says: when you get a new piece, tell ALL your neighbors about it
@@ -328,3 +363,41 @@ class ProtocolPeerNode(PeerNode):
             remote_id,
             PeerMessageState(peer_bitfield=Bitfield(self.common.num_pieces)),
         )
+
+    def _on_choke_state_change(self, choke_state: dict[int, bool]) -> None:
+        messages_to_send: list[tuple[int, MsgType]] = []
+
+        with self.state_lock:
+            for remote_id, is_choked in choke_state.items():
+                state = self._get_state(remote_id)
+                if state.am_choking_peer == is_choked:
+                    continue
+                state.am_choking_peer = is_choked
+                if is_choked:
+                    messages_to_send.append((remote_id, MsgType.CHOKE))
+                else:
+                    messages_to_send.append((remote_id, MsgType.UNCHOKE))
+
+        for remote_id, msg_type in messages_to_send:
+            self.send_message(remote_id, Message(msg_type))
+
+    def is_network_complete(self) -> bool:
+        return self.all_complete_event.is_set()
+
+    def _update_completion_state(self) -> None:
+        with self.state_lock:
+            if not self.local_bitfield.is_complete():
+                return
+
+            expected_peer_count = len(self.peers) - 1
+            if len(self.peer_states) < expected_peer_count:
+                return
+
+            for peer_id in self.peers:
+                if peer_id == self.self_id:
+                    continue
+                state = self.peer_states.get(peer_id)
+                if state is None or not state.peer_bitfield.is_complete():
+                    return
+
+        self.all_complete_event.set()

--- a/tests/test_message_protocol_flow.py
+++ b/tests/test_message_protocol_flow.py
@@ -3,6 +3,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import connection_manager.protocol_node as protocol_node_module
 from connection_manager.config import CommonConfig, PeerInfo
 from connection_manager.protocol_node import ProtocolPeerNode
 from protocol.messages import Message, MsgType, parse_have_payload, parse_request_payload
@@ -56,6 +57,18 @@ class RecordingProtocolPeerNode(ProtocolPeerNode):
         self.sent_messages.append((remote_id, msg))
 
 
+class patch_random_choice:
+    def __init__(self, replacement):
+        self.replacement = replacement
+        self.original = protocol_node_module.random.choice
+
+    def __enter__(self):
+        protocol_node_module.random.choice = self.replacement
+
+    def __exit__(self, exc_type, exc, tb):
+        protocol_node_module.random.choice = self.original
+
+
 def make_node() -> RecordingProtocolPeerNode:
     peers = {
         1: PeerInfo(peer_id=1, host="127.0.0.1", port=6001, has_file=False),
@@ -85,9 +98,10 @@ def test_bitfield_drives_interest_and_request() -> None:
         (2, MsgType.INTERESTED)
     ]
 
-    node.on_message(2, Message(MsgType.UNCHOKE))
+    with patch_random_choice(lambda candidates: candidates[-1]):
+        node.on_message(2, Message(MsgType.UNCHOKE))
     assert node.sent_messages[-1][1].msg_type == MsgType.REQUEST
-    assert parse_request_payload(node.sent_messages[-1][1].payload) == 0
+    assert parse_request_payload(node.sent_messages[-1][1].payload) == 2
 
 
 def test_piece_reception_broadcasts_have_and_requests_next_piece() -> None:
@@ -97,10 +111,12 @@ def test_piece_reception_broadcasts_have_and_requests_next_piece() -> None:
     node.sent_messages.clear()
 
     node.on_message(2, Message(MsgType.BITFIELD, b"\xe0"))
-    node.on_message(2, Message(MsgType.UNCHOKE))
+    with patch_random_choice(lambda candidates: candidates[0]):
+        node.on_message(2, Message(MsgType.UNCHOKE))
     node.sent_messages.clear()
 
-    node.on_message(2, Message(MsgType.PIECE, b"\x00\x00\x00\x00abcd"))
+    with patch_random_choice(lambda candidates: candidates[0]):
+        node.on_message(2, Message(MsgType.PIECE, b"\x00\x00\x00\x00abcd"))
 
     sent_summary = [(peer_id, msg.msg_type) for peer_id, msg in node.sent_messages]
     assert (2, MsgType.HAVE) in sent_summary
@@ -118,7 +134,8 @@ def test_choke_clears_pending_request_and_unchoke_retries() -> None:
     node.sent_messages.clear()
 
     node.on_message(2, Message(MsgType.BITFIELD, b"\xe0"))
-    node.on_message(2, Message(MsgType.UNCHOKE))
+    with patch_random_choice(lambda candidates: candidates[0]):
+        node.on_message(2, Message(MsgType.UNCHOKE))
     first_request = parse_request_payload(node.sent_messages[-1][1].payload)
     assert first_request == 0
 
@@ -126,14 +143,85 @@ def test_choke_clears_pending_request_and_unchoke_retries() -> None:
     assert node.peer_states[2].requested_piece is None
     assert 0 not in node.pending_requests
 
-    node.on_message(2, Message(MsgType.UNCHOKE))
+    with patch_random_choice(lambda candidates: candidates[0]):
+        node.on_message(2, Message(MsgType.UNCHOKE))
     assert parse_request_payload(node.sent_messages[-1][1].payload) == 0
+
+
+def test_choking_handler_sends_unchoke_and_choke_messages() -> None:
+    node = make_node()
+    node.on_connected(2)
+    node.sent_messages.clear()
+
+    node.on_message(2, Message(MsgType.INTERESTED))
+    node.choking_handler.select_preferred_neighbors()
+    assert [(peer_id, msg.msg_type) for peer_id, msg in node.sent_messages] == [
+        (2, MsgType.UNCHOKE)
+    ]
+
+    node.sent_messages.clear()
+    node.on_message(2, Message(MsgType.NOT_INTERESTED))
+    node.choking_handler.select_preferred_neighbors()
+    assert [(peer_id, msg.msg_type) for peer_id, msg in node.sent_messages] == [
+        (2, MsgType.CHOKE)
+    ]
+
+
+def test_request_is_ignored_while_we_are_choking_peer() -> None:
+    node = make_node()
+    node.local_bitfield.set_piece(0)
+    node.file_storage.write_piece(0, b"abcd")
+    node.sent_messages.clear()
+
+    node.on_connected(2)
+    node.sent_messages.clear()
+    node.on_message(2, Message(MsgType.REQUEST, b"\x00\x00\x00\x00"))
+    assert node.sent_messages == []
+
+
+def test_random_piece_selection_skips_pending_requests() -> None:
+    node = make_node()
+    node.on_connected(2)
+    node.on_message(2, Message(MsgType.BITFIELD, b"\xe0"))
+    node.pending_requests.add(0)
+    node.pending_requests.add(1)
+
+    chosen_candidates: list[list[int]] = []
+
+    def choose_last(candidates):
+        chosen_candidates.append(list(candidates))
+        return candidates[-1]
+
+    with patch_random_choice(choose_last):
+        node.on_message(2, Message(MsgType.UNCHOKE))
+
+    assert chosen_candidates == [[2]]
+    assert parse_request_payload(node.sent_messages[-1][1].payload) == 2
+
+
+def test_completion_detected_when_all_peer_bitfields_are_complete() -> None:
+    node = make_node()
+    node.local_bitfield.set_piece(0)
+    node.local_bitfield.set_piece(1)
+    node.local_bitfield.set_piece(2)
+
+    node.on_connected(2)
+    node.on_connected(3)
+    node.on_message(2, Message(MsgType.BITFIELD, b"\xe0"))
+    assert not node.is_network_complete()
+
+    node.on_message(3, Message(MsgType.BITFIELD, b"\xe0"))
+    assert node.is_network_complete()
 
 
 def run_all_tests() -> None:
     test_bitfield_drives_interest_and_request()
     test_piece_reception_broadcasts_have_and_requests_next_piece()
     test_choke_clears_pending_request_and_unchoke_retries()
+    test_choking_handler_sends_unchoke_and_choke_messages()
+    test_request_is_ignored_while_we_are_choking_peer()
+    test_random_piece_selection_skips_pending_requests()
+    test_completion_detected_when_all_peer_bitfields_are_complete()
     print("Message protocol flow tests passed")
 
 


### PR DESCRIPTION
- Integrated ChokingHandler into the live protocol flow in connection_manager/protocol_node.py
- replaced placeholder unchoking with real CHOKE and UNCHOKE message sending based on choking state changes
- made incoming REQUEST handling respect whether the peer is currently choked
- switched piece selection to random among valid missing pieces
- added completion detection across peers and automatic shutdown once the network is complete
- added connection retry logic in connection_manager/network.py so peers can start reliably without early connection refusal failures
- added live TCP connection logging in the network layer
- expanded protocol flow tests to cover choking integration, random request selection, request rejection while choking, and completion detection